### PR TITLE
(feat: add responseDto)공통 ResponseDto 생성

### DIFF
--- a/src/main/java/com/weatherwhere/weatherservice/dto/ResultDto.java
+++ b/src/main/java/com/weatherwhere/weatherservice/dto/ResultDto.java
@@ -1,0 +1,12 @@
+package com.weatherwhere.weatherservice.dto;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class ResultDto<T> {
+    private final int resultCode;
+    private final String message;
+    private final T data;
+}


### PR DESCRIPTION
# 공통 responseDto
### 공통 Response DTO를 사용하는 경우, 모든 API 응답에 대해 동일한 필드(예: 응답 코드, 메시지, 데이터 등)를 포함하는 단일 클래스를 정의합니다. 이렇게 하면 코드의 중복을 줄이고, API 응답을 쉽게 유지 보수하고 업데이트할 수 있습니다.

<img width="371" alt="image" src="https://user-images.githubusercontent.com/40010878/229159681-965fafea-891c-484b-8824-bc34252da5eb.png">

- response 에서 요청된 응답 값만 전달해주는게 아니라 결과에 대한 코드, 메세지, 데이터 포맷으로 전달해줘 프론트에서 더 효율적으로 사용하게 하기 위한 목적
- 공통 responseDto를 만들어 data 타입을 제네릭으로 지정!

### 아래는 air에서 예시! air 레포 참고하세요! 

- 에러 발생했을 때
![image](https://user-images.githubusercontent.com/40010878/229160645-6fb925e1-3906-4ccc-a4a1-286bcce20bb9.png)

- 성공했을 때
<img width="547" alt="image" src="https://user-images.githubusercontent.com/40010878/229161428-4f73fd85-cb4f-4347-be6b-6ae797e9de0a.png">