### PR TITLE
Refactor/weather short entity

### DIFF
--- a/src/main/java/com/weatherwhere/weatherservice/controller/weathershort/WeatherShortController.java
+++ b/src/main/java/com/weatherwhere/weatherservice/controller/weathershort/WeatherShortController.java
@@ -1,5 +1,7 @@
 package com.weatherwhere.weatherservice.controller.weathershort;
 
+import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortMain;
+import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortSub;
 import com.weatherwhere.weatherservice.dto.ResultDTO;
 import com.weatherwhere.weatherservice.dto.weathershort.WeatherShortMainApiRequestDTO;
 import com.weatherwhere.weatherservice.dto.weathershort.WeatherShortRequestDTO;
@@ -8,6 +10,10 @@ import com.weatherwhere.weatherservice.service.weathershort.WeatherShortMainApiS
 import com.weatherwhere.weatherservice.service.weathershort.WeatherShortMainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 @RestController
 @RequestMapping("weather")
@@ -22,9 +28,14 @@ public class WeatherShortController {
     @GetMapping("/forecast/short")
     public String weatherShortMainEntityList(@ModelAttribute WeatherShortRequestDTO weatherShortRequestDTO) throws Exception {
         try {
-            return weatherShortMainService.saveWeatherShortEntity(weatherShortRequestDTO);
+
+            List<WeatherShortMain> mainEntityList = Collections.synchronizedList(new ArrayList<>());
+            List<WeatherShortSub> subEntityList = Collections.synchronizedList(new ArrayList<>());
+
+            return weatherShortMainService.getXYListWeatherAllSave(weatherShortRequestDTO, mainEntityList, subEntityList);
 
         } catch (Exception e) {
+            e.printStackTrace();
             throw new Exception(e);
 
         }

--- a/src/main/java/com/weatherwhere/weatherservice/domain/weathershort/WeatherShortCompositeKey.java
+++ b/src/main/java/com/weatherwhere/weatherservice/domain/weathershort/WeatherShortCompositeKey.java
@@ -1,0 +1,25 @@
+package com.weatherwhere.weatherservice.domain.weathershort;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Embeddable
+public class WeatherShortCompositeKey implements Serializable {
+    //예보날짜+시간
+    @Column(name = "fcst_date_time")
+    private LocalDateTime fcstDateTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "weather_xy_id")
+    @MapsId("weatherXY")
+    private WeatherXY weatherXY;
+
+}

--- a/src/main/java/com/weatherwhere/weatherservice/domain/weathershort/WeatherShortMain.java
+++ b/src/main/java/com/weatherwhere/weatherservice/domain/weathershort/WeatherShortMain.java
@@ -2,6 +2,7 @@ package com.weatherwhere.weatherservice.domain.weathershort;
 
 
 import com.weatherwhere.weatherservice.domain.BaseEntity;
+import com.weatherwhere.weatherservice.domain.weathermid.WeatherMidCompositeKey;
 import com.weatherwhere.weatherservice.dto.weathershort.WeatherShortAllDTO;
 import jakarta.persistence.*;
 import lombok.*;
@@ -9,19 +10,15 @@ import java.time.LocalDateTime;
 
 @Builder
 @Entity
-@Table(name="weather_short_term_main", schema = "weather",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"fcst_date_time", "weather_xy_id"})})
+@Table(name="weather_short_term_main", schema = "weather")
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@ToString(exclude = "weatherXY")
 public class WeatherShortMain extends BaseEntity {
 
-    //identity방식으로 아이디 1씩 자동증가
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
-    @Column(name = "weather_short_id")
-    private Long weatherShortId;
+    // 단기 예보 식별자
+    @EmbeddedId
+    private WeatherShortCompositeKey id;
 
     //발표날짜
     @Column(name = "base_date")
@@ -30,10 +27,6 @@ public class WeatherShortMain extends BaseEntity {
     //발표시간
     @Column(name = "base_time")
     private String baseTime;
-
-    //예보날짜+시간
-    @Column(name = "fcst_date_time")
-    private LocalDateTime fcstDateTime;
 
     //강수확률
     @Column(name = "pop")
@@ -70,10 +63,6 @@ public class WeatherShortMain extends BaseEntity {
     @Column(name = "reh")
     private Double reh;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "weather_xy_id")
-    private WeatherXY weatherXY;
-
     //테이블 값 업데이트
     public void update(WeatherShortAllDTO dto) {
         this.pop = dto.getPop();
@@ -89,10 +78,5 @@ public class WeatherShortMain extends BaseEntity {
     }
 
 
-
-    //테이블 값 set
-    public void setWeatherXY(WeatherXY weatherXY){
-        this.weatherXY =weatherXY;
-    }
 
 }

--- a/src/main/java/com/weatherwhere/weatherservice/domain/weathershort/WeatherShortSub.java
+++ b/src/main/java/com/weatherwhere/weatherservice/domain/weathershort/WeatherShortSub.java
@@ -7,20 +7,16 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name="weather_short_term_sub", schema = "weather",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"fcst_date_time", "weather_xy_id"})})
+@Table(name="weather_short_term_sub", schema = "weather")
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@ToString(exclude = "weatherXY")
 public class WeatherShortSub extends BaseEntity {
 
-    //identity방식으로 아이디 1씩 자동증가
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE)
-    @Column(name = "weather_short_id")
-    private Long weatherShortId;
+    // 단기 예보 식별자
+    @EmbeddedId
+    private WeatherShortCompositeKey id;
 
     //발표날짜
     @Column(name = "base_date")
@@ -29,10 +25,6 @@ public class WeatherShortSub extends BaseEntity {
     //발표시간
     @Column(name = "base_time")
     private String baseTime;
-
-    //예보날짜+시간
-    @Column(name = "fcst_date_time")
-    private LocalDateTime fcstDateTime;
 
     //1시간 강수량
     @Column(name = "pcp")
@@ -59,10 +51,6 @@ public class WeatherShortSub extends BaseEntity {
     private Double vec;
 
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "weather_xy_id")
-    private WeatherXY weatherXY;
-
     public void update(WeatherShortAllDTO dto) {
         this.pcp = dto.getPcp();
         this.sno = dto.getSno();
@@ -72,10 +60,6 @@ public class WeatherShortSub extends BaseEntity {
         this.vec = dto.getVec();
         this.baseTime = dto.getBaseTime();
         this.baseDate = dto.getBaseDate();
-    }
-
-    public void setWeatherXY(WeatherXY weatherXY){
-        this.weatherXY =weatherXY;
     }
 
 

--- a/src/main/java/com/weatherwhere/weatherservice/domain/weathershort/WeatherXY.java
+++ b/src/main/java/com/weatherwhere/weatherservice/domain/weathershort/WeatherXY.java
@@ -5,6 +5,7 @@ import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortSub;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -29,11 +30,13 @@ public class WeatherXY {
     private Integer weatherY;
 
 
- /*   @OneToMany(mappedBy = "weatherXY")
-    private List<WeatherShortMain> weatherShortMainList;
+    @OneToMany(mappedBy = "id.weatherXY", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private final List<WeatherShortMain> weatherShortMainList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "weatherXY")
-    private List<WeatherShortSub> weatherShortSubList;
-*/
+
+    @OneToMany(mappedBy = "id.weatherXY", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private final List<WeatherShortSub> weatherShortSubList = new ArrayList<>();
+
+
 
 }

--- a/src/main/java/com/weatherwhere/weatherservice/dto/weathershort/WeatherShortAllDTO.java
+++ b/src/main/java/com/weatherwhere/weatherservice/dto/weathershort/WeatherShortAllDTO.java
@@ -62,7 +62,9 @@ public class WeatherShortAllDTO {
     //풍량
     private Double vec;
 
-    private WeatherXY weatherXY;
+    private Integer nx;
+
+    private Integer ny;
 
 
 }

--- a/src/main/java/com/weatherwhere/weatherservice/repository/weathershort/WeatherShortMainRepository.java
+++ b/src/main/java/com/weatherwhere/weatherservice/repository/weathershort/WeatherShortMainRepository.java
@@ -1,19 +1,32 @@
 package com.weatherwhere.weatherservice.repository.weathershort;
 
+import com.weatherwhere.weatherservice.domain.weathermid.WeatherMidCompositeKey;
+import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortCompositeKey;
 import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortMain;
 import com.weatherwhere.weatherservice.domain.weathershort.WeatherXY;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.time.LocalDateTime;
+import java.util.List;
 
-public interface WeatherShortMainRepository extends JpaRepository<WeatherShortMain, Long> {
-
+public interface WeatherShortMainRepository extends JpaRepository<WeatherShortMain, WeatherShortCompositeKey> {
+/*
     WeatherShortMain findByFcstDateTimeAndWeatherXY(LocalDateTime fcstDateTime, WeatherXY weatherXY);
+
 
     @Query("SELECT n.tmn FROM WeatherShortMain n Where n.fcstDateTime = :fcstDateTime AND n.weatherXY = :weatherXY ")
     Double findTmnByFcstDateTimeAndWeatherXY(LocalDateTime fcstDateTime, WeatherXY weatherXY);
 
     @Query("SELECT n.tmx FROM WeatherShortMain n Where n.fcstDateTime = :fcstDateTime AND n.weatherXY = :weatherXY ")
     Double findTmxByFcstDateTimeAndWeatherXY(LocalDateTime fcstDateTime, WeatherXY weatherXY);
+
+    @Query("SELECT wsm FROM WeatherShortMain wsm JOIN wsm.weatherXY wx WHERE wx.weatherX = :nx AND wx.weatherY = :ny AND wsm.fcstDateTime = :fcstDateTime")
+    WeatherShortMain findByWeatherXWeatherYAndFcstDateTime(Integer nx, Integer ny, LocalDateTime fcstDateTime);
+*/
+
+
+
 
 }

--- a/src/main/java/com/weatherwhere/weatherservice/repository/weathershort/WeatherShortSubRepository.java
+++ b/src/main/java/com/weatherwhere/weatherservice/repository/weathershort/WeatherShortSubRepository.java
@@ -1,15 +1,22 @@
 package com.weatherwhere.weatherservice.repository.weathershort;
 
+import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortCompositeKey;
+import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortMain;
 import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortSub;
 import com.weatherwhere.weatherservice.domain.weathershort.WeatherXY;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 
-public interface WeatherShortSubRepository extends JpaRepository<WeatherShortSub, Long> {
+public interface WeatherShortSubRepository extends JpaRepository<WeatherShortSub, WeatherShortCompositeKey> {
 
+/*
     WeatherShortSub findByFcstDateTimeAndWeatherXY(LocalDateTime fcstDateTime, WeatherXY weatherXY);
 
+    @Query("SELECT wsm FROM WeatherShortSub wsm JOIN wsm.weatherXY wx WHERE wx.weatherX = :nx AND wx.weatherY = :ny AND wsm.fcstDateTime = :fcstDateTime")
+    WeatherShortSub findByWeatherXWeatherYAndFcstDateTime(Integer nx, Integer ny, LocalDateTime fcstDateTime);
+*/
 
 
 }

--- a/src/main/java/com/weatherwhere/weatherservice/repository/weathershort/WeatherXYRepository.java
+++ b/src/main/java/com/weatherwhere/weatherservice/repository/weathershort/WeatherXYRepository.java
@@ -4,11 +4,17 @@ import com.weatherwhere.weatherservice.domain.weathershort.WeatherXY;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface WeatherXYRepository extends JpaRepository<WeatherXY, Long> {
 
     WeatherXY findByWeatherXAndWeatherY(Integer nx, Integer ny);
+/*
+
+    List<WeatherXY> findByWeatherShortMainListFcstDateTimeAndWeatherXAndWeatherY(LocalDateTime fcstDateTime, Integer nx, Integer ny);
+*/
+
 
     @Query("SELECT wx.weatherX, wy.weatherY FROM WeatherXY wx, WeatherXY wy WHERE wx.id = wy.id")
     List<Object[]> findAllNxAndNy();

--- a/src/main/java/com/weatherwhere/weatherservice/service/weathershort/WeatherShortMainApiService.java
+++ b/src/main/java/com/weatherwhere/weatherservice/service/weathershort/WeatherShortMainApiService.java
@@ -19,9 +19,8 @@ public interface WeatherShortMainApiService {
 
     default WeatherShortMainDTO nowEntityToDTO(WeatherShortMain entity, Double tmn, Double tmx) {
         WeatherShortMainDTO dto = WeatherShortMainDTO.builder()
-                .weatherShortId(entity.getWeatherShortId())
-                .weatherXYId(entity.getWeatherXY().getId())
-                .fcstDateTime(entity.getFcstDateTime())
+/*                .weatherShortId(entity.getWeatherShortId())
+                .weatherXYId(entity.getWeatherXY().getId())*/
                 .pop(entity.getPop())
                 .pty(entity.getPty())
                 .reh(entity.getReh())
@@ -36,9 +35,8 @@ public interface WeatherShortMainApiService {
 
     default WeatherShortMainDTO entityToDTO(WeatherShortMain entity) {
         WeatherShortMainDTO dto = WeatherShortMainDTO.builder()
-                .weatherShortId(entity.getWeatherShortId())
-                .weatherXYId(entity.getWeatherXY().getId())
-                .fcstDateTime(entity.getFcstDateTime())
+/*                .weatherShortId(entity.getWeatherShortId())
+                .weatherXYId(entity.getWeatherXY().getId())*/
                 .pop(entity.getPop())
                 .pty(entity.getPty())
                 .reh(entity.getReh())
@@ -51,9 +49,9 @@ public interface WeatherShortMainApiService {
 
     default WeatherShortSubDTO subEntityToDTO(WeatherShortSub entity) {
         WeatherShortSubDTO dto = WeatherShortSubDTO.builder()
-                .weatherShortId(entity.getWeatherShortId())
+/*                .weatherShortId(entity.getWeatherShortId())
                 .weatherXYId(entity.getWeatherXY().getId())
-                .fcstDateTime(entity.getFcstDateTime())
+                .fcstDateTime(entity.getFcstDateTime())*/
                 .pcp(entity.getPcp())
                 .sno(entity.getSno())
                 .uuu(entity.getUuu())

--- a/src/main/java/com/weatherwhere/weatherservice/service/weathershort/WeatherShortMainApiServiceImpl.java
+++ b/src/main/java/com/weatherwhere/weatherservice/service/weathershort/WeatherShortMainApiServiceImpl.java
@@ -94,8 +94,8 @@ public class WeatherShortMainApiServiceImpl implements WeatherShortMainApiServic
                 LocalDateTime now = LocalDateTime.now();
                 LocalDateTime ldt = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(), now.getHour(), 0).plusHours(i);
                 requestDTO.setFcstDateTime(ldt);
-                WeatherShortMain weatherShortMain = weatherShortMainRepository.findByFcstDateTimeAndWeatherXY(requestDTO.getFcstDateTime(), weatherXY);
-                mainDataList.add(entityToDTO(weatherShortMain));
+                //WeatherShortMain weatherShortMain = weatherShortMainRepository.findByFcstDateTimeAndWeatherXY(requestDTO.getFcstDateTime(), weatherXY);
+                //mainDataList.add(entityToDTO(weatherShortMain));
             }
             return ResultDTO.of(HttpStatus.OK.value(),"메인 데이터(12시간)를 반환하는데 성공했습니다.",mainDataList);
         } catch (NullPointerException e) {
@@ -116,15 +116,15 @@ public class WeatherShortMainApiServiceImpl implements WeatherShortMainApiServic
             LocalDateTime tmn = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(), 6, 0);
             LocalDateTime tmx = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(), 15, 0);
             requestDTO.setFcstDateTime(ldt);
-            WeatherShortMain weatherShortMain = weatherShortMainRepository.findByFcstDateTimeAndWeatherXY(requestDTO.getFcstDateTime(), weatherXY);
+            //WeatherShortMain weatherShortMain = weatherShortMainRepository.findByFcstDateTimeAndWeatherXY(requestDTO.getFcstDateTime(), weatherXY);
             //6시의 최저기온
-            Double weatherShortMainTmn = weatherShortMainRepository.findTmnByFcstDateTimeAndWeatherXY(tmn, weatherXY);
+            //Double weatherShortMainTmn = weatherShortMainRepository.findTmnByFcstDateTimeAndWeatherXY(tmn, weatherXY);
             //15시의 최고기온
-            Double weatherShortMainTmx = weatherShortMainRepository.findTmxByFcstDateTimeAndWeatherXY(tmx, weatherXY);
-            System.out.println("최고기온: "+weatherShortMainTmx);
-            WeatherShortMainDTO mainData = nowEntityToDTO(weatherShortMain, weatherShortMainTmn, weatherShortMainTmx);
-            System.out.println("nowMainData: "+mainData);
-            return ResultDTO.of(HttpStatus.OK.value(),"메인 데이터(현재시간)를 반환하는데 성공했습니다.",mainData);
+            //Double weatherShortMainTmx = weatherShortMainRepository.findTmxByFcstDateTimeAndWeatherXY(tmx, weatherXY);
+            //System.out.println("최고기온: "+weatherShortMainTmx);
+            //WeatherShortMainDTO mainData = nowEntityToDTO(weatherShortMain, weatherShortMainTmn, weatherShortMainTmx);
+            //System.out.println("nowMainData: "+mainData);
+            return ResultDTO.of(HttpStatus.OK.value(),"메인 데이터(현재시간)를 반환하는데 성공했습니다.",null);
         } catch (NullPointerException e) {
             return ResultDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "NullPointerExceptiond이 발생했습니다.", null);
         } catch (Exception e) {
@@ -145,8 +145,8 @@ public class WeatherShortMainApiServiceImpl implements WeatherShortMainApiServic
                 LocalDateTime now = LocalDateTime.now();
                 LocalDateTime ldt = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(), now.getHour(), 0).plusHours(i);
                 requestDTO.setFcstDateTime(ldt);
-                WeatherShortSub weatherShortSub = weatherShortSubRepository.findByFcstDateTimeAndWeatherXY(requestDTO.getFcstDateTime(), weatherXY);
-                subDataList.add(subEntityToDTO(weatherShortSub));
+                //WeatherShortSub weatherShortSub = weatherShortSubRepository.findByFcstDateTimeAndWeatherXY(requestDTO.getFcstDateTime(), weatherXY);
+                //subDataList.add(subEntityToDTO(weatherShortSub));
             }
             return ResultDTO.of(HttpStatus.OK.value(),"서브 데이터를 반환하는데 성공했습니다.",subDataList);
         } catch (NullPointerException e) {

--- a/src/main/java/com/weatherwhere/weatherservice/service/weathershort/WeatherShortMainService.java
+++ b/src/main/java/com/weatherwhere/weatherservice/service/weathershort/WeatherShortMainService.java
@@ -1,28 +1,27 @@
 package com.weatherwhere.weatherservice.service.weathershort;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.weatherwhere.weatherservice.domain.weathermid.WeatherMidCompositeKey;
+import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortCompositeKey;
 import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortMain;
 import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortSub;
+import com.weatherwhere.weatherservice.domain.weathershort.WeatherXY;
 import com.weatherwhere.weatherservice.dto.weathershort.WeatherShortAllDTO;
 import com.weatherwhere.weatherservice.dto.weathershort.WeatherShortRequestDTO;
+import jakarta.transaction.Transactional;
 
 import java.net.URISyntaxException;
+import java.util.List;
 
 public interface WeatherShortMainService {
 
 
-    //dto리스트를 entity리스트로 변환한 뒤 db에 save하는 메서드
-    //컨트롤러에서 최종적으로 이 service를 호출함.
-    String saveWeatherShortEntity(WeatherShortRequestDTO weatherShortRequestDTO) throws Exception;
-
-    //String readWeatherXYLocation() throws IOException;
-
     // 단기예보 메인 DTO -> Entity
-    default WeatherShortMain mainDtoToEntity(WeatherShortAllDTO dto) {
+    default WeatherShortMain mainDtoToEntity(WeatherShortAllDTO dto, WeatherXY weatherXY) {
+        WeatherShortCompositeKey weatherShortCompositeKey = new WeatherShortCompositeKey(dto.getFcstDateTime(), weatherXY);
         WeatherShortMain weatherShortMain = WeatherShortMain.builder()
                 .baseDate(dto.getBaseDate())
                 .baseTime(dto.getBaseTime())
-                .fcstDateTime(dto.getFcstDateTime())
                 .pop(dto.getPop())
                 .pty(dto.getPty())
                 .reh(dto.getReh())
@@ -31,29 +30,29 @@ public interface WeatherShortMainService {
                 .wsd(dto.getWsd())
                 .tmn(dto.getTmn())
                 .tmx(dto.getTmx())
-                .weatherXY(dto.getWeatherXY())
+                .id(weatherShortCompositeKey)
                 .build();
         return weatherShortMain;
     }
 
     //단기예보 서브 DTO -> Entity
-    default WeatherShortSub subDtoToEntity(WeatherShortAllDTO dto) {
+    default WeatherShortSub subDtoToEntity(WeatherShortAllDTO dto,WeatherXY weatherXY) {
+        WeatherShortCompositeKey weatherShortCompositeKey = new WeatherShortCompositeKey(dto.getFcstDateTime(), weatherXY);
         WeatherShortSub weatherShortSub = WeatherShortSub.builder()
                 .baseDate(dto.getBaseDate())
                 .baseTime(dto.getBaseTime())
-                .fcstDateTime(dto.getFcstDateTime())
                 .pcp(dto.getPcp())
                 .sno(dto.getSno())
                 .uuu(dto.getUuu())
                 .vvv(dto.getVvv())
                 .wav(dto.getWav())
                 .vec(dto.getVec())
-                .weatherXY(dto.getWeatherXY())
+                .id(weatherShortCompositeKey)
                 .build();
         return weatherShortSub;
     }
 
-
+    String getXYListWeatherAllSave(WeatherShortRequestDTO weatherShortRequestDTO, List<WeatherShortMain> mainEntityList, List<WeatherShortSub> subEntityList) throws Exception;
 
 
 

--- a/src/test/java/com/weatherwhere/weatherservice/WeatherShortTests.java
+++ b/src/test/java/com/weatherwhere/weatherservice/WeatherShortTests.java
@@ -3,6 +3,7 @@ package com.weatherwhere.weatherservice;
 import com.weatherwhere.weatherservice.domain.weathershort.WeatherShortMain;
 import com.weatherwhere.weatherservice.domain.weathershort.WeatherXY;
 import com.weatherwhere.weatherservice.dto.weathershort.WeatherShortMainApiRequestDTO;
+import com.weatherwhere.weatherservice.repository.weathershort.WeatherShortMainRepository;
 import com.weatherwhere.weatherservice.repository.weathershort.WeatherXYRepository;
 import com.weatherwhere.weatherservice.service.weathershort.WeatherShortMainApiService;
 import org.junit.Ignore;
@@ -16,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -35,13 +37,16 @@ public class WeatherShortTests {
     @Autowired
     private WeatherXYRepository weatherXYRepository;
 
+    @Autowired
+    private WeatherShortMainRepository weatherShortMainRepository;
+
 
     @Test
     @DisplayName("nx,ny별 단기예보 데이터 불러오기 테스트")
     @Disabled
     void testNxNyRepeat() throws Exception {
-        String baseDate = "20230401";
-        String baseTime = "0500";
+        String baseDate = "20230406";
+        String baseTime = "2000";
         MvcResult result = mockMvc.perform(get("/weather/forecast/short")
                         .param("baseDate", baseDate)
                         .param("baseTime", baseTime))
@@ -94,4 +99,9 @@ public class WeatherShortTests {
         }
 
     }
+
+
+
+
+
 }


### PR DESCRIPTION
- [x] 기본키 -> fcstDateTime,WeatherXY 복합키로 변경하여 자동 업데이트 (select 쿼리 삭제)
- [x] 서비스 메서드 분리
- [x] parallelstream 사용하여 db 업데이트 로직 병렬화
- [x] 성능 비교 결과
- 기존 fulltable scan방식에서 join하는 방식으로 변경하였는데 시간의 차이는 그다지 없었음
- 100개의 nx,ny기준
1) 기존 방식 - 3분
2) 복합키,  엔티티리스트 병렬처리(parallelstream) - 1분56초
3) 복합키, 엔티티리스트(parallelstream), xylist(stream) -  1분11초(현재 코드)
4) 다~ stream - 2분 30초
5) 복합키, 엔티티리스트(parallelstream), xylist(parallelstream) - xylist를 병렬처리하면 특정 x,y들만 db에 업데이트되는 문제 발생